### PR TITLE
Fix LLMConfig parameter error in tool_call step handler

### DIFF
--- a/agent_orchestration/step_handlers.py
+++ b/agent_orchestration/step_handlers.py
@@ -3062,22 +3062,35 @@ class StepHandlerRegistry:
             tool_service = ToolService(credential_manager=credential_manager)
 
             # Get LLM service based on provider
+            from llm.llm_types import LLMConfig, LLMProvider
+            
             if provider == "gemini":
                 from llm.text_clients import GeminiTextClient
-
-                llm_client = GeminiTextClient(temperature=temperature)
+                
+                config = LLMConfig(
+                    provider=LLMProvider.GEMINI,
+                    model=model,
+                    temperature=temperature
+                )
+                llm_client = GeminiTextClient(config)
             elif provider == "ollama":
                 from llm.text_clients import OllamaTextClient
-
-                llm_client = OllamaTextClient(
-                    model=model or "llama3.1:8b", temperature=temperature
+                
+                config = LLMConfig(
+                    provider=LLMProvider.OLLAMA,
+                    model=model or "llama3.1:8b",
+                    temperature=temperature
                 )
+                llm_client = OllamaTextClient(config)
             elif provider == "openai":
                 from llm.text_clients import OpenAITextClient
-
-                llm_client = OpenAITextClient(
-                    model=model or "gpt-4", temperature=temperature
+                
+                config = LLMConfig(
+                    provider=LLMProvider.OPENAI,
+                    model=model or "gpt-4",
+                    temperature=temperature
                 )
+                llm_client = OpenAITextClient(config)
             else:
                 raise ValueError(f"Unsupported provider: {provider}")
 


### PR DESCRIPTION
## Summary

Fixes the  error that occurs when using the  step type in agent orchestration workflows.

## Root Cause

The  method in  was still using the old direct parameter API to instantiate LLM clients:

```python
# OLD (broken)
llm_client = OllamaTextClient(model=model, temperature=temperature)
```

But the LLM clients were updated to expect an `LLMConfig` object as the first parameter.

## Solution

Updated all LLM client instantiations to use the new `LLMConfig` object pattern:

```python  
# NEW (working)
config = LLMConfig(
    provider=LLMProvider.OLLAMA,
    model=model or "llama3.1:8b",
    temperature=temperature
)
llm_client = OllamaTextClient(config)
```

## Changes Made

- ✅ Updated Gemini client instantiation to use LLMConfig
- ✅ Updated Ollama client instantiation to use LLMConfig  
- ✅ Updated OpenAI client instantiation to use LLMConfig
- ✅ Added proper imports for LLMConfig and LLMProvider
- ✅ Maintains backwards compatibility with existing step configurations

## Testing

- Tested with Ollama provider using `unsloth/DeepSeek-R1-0528-Qwen3-8B-GGUF` model
- Confirmed the original `TypeError` is resolved
- Agent orchestrator can now properly instantiate LLM clients

## Known Limitation

This fix resolves the client instantiation error, but there's a separate issue where the `chat_with_tools` method is no longer available in the updated LLM clients. The tool calling workflow will need further updates to work with the new ToolService architecture, but that's beyond the scope of this specific fix.

## Related Issue

Closes #2 (partial fix - resolves the LLMConfig parameter error)